### PR TITLE
Fix contact directory integration - connect Home page saves to SQLite

### DIFF
--- a/connect-grow-hire/src/pages/Home.tsx
+++ b/connect-grow-hire/src/pages/Home.tsx
@@ -225,11 +225,11 @@ const Home = () => {
     try {
       if (!hasResults) return;
       const mapped = lastResults.map(mapToDirectoryContact);
-      const resp = await fetch(`${BACKEND_URL}/api/contacts/bulk`, {
+      const resp = await fetch(`${BACKEND_URL}/api/directory/contacts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          userId: mockUser.email || 'test@example.com',
+          userEmail: mockUser.email || 'test@example.com',
           contacts: mapped
         })
       });
@@ -241,7 +241,7 @@ const Home = () => {
       const data = await resp.json();
       toast({
         title: "Saved to Contact Directory",
-        description: `Created ${data.created}, skipped ${data.skipped} duplicates.`
+        description: `Saved ${data.saved} contacts to directory.`
       });
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
# Fix contact directory integration - connect Home page saves to SQLite

## Summary
Fixes the issue where contacts saved from the Home page search results didn't appear in the Contact Directory. The problem was that the Home page was saving contacts to a Firebase endpoint (`/api/contacts/bulk`) while the Contact Directory was reading from a SQLite endpoint (`/api/directory/contacts`).

**Changes:**
- Updated `handleSaveToDirectory` in Home.tsx to use `/api/directory/contacts` instead of `/api/contacts/bulk`
- Changed request payload from `userId` to `userEmail` to match SQLite endpoint expectations
- Updated success toast message to show `Saved X contacts` instead of `Created X, skipped Y duplicates`

## Review & Testing Checklist for Human
- [ ] **Test complete user flow**: Search for contacts on Home page → Click "Save to Directory" → Navigate to Contact Directory page and verify contacts appear in the table
- [ ] **Verify contact data integrity**: Check that all contact fields (name, email, LinkedIn, company, title, location) are correctly saved and displayed
- [ ] **Test edge cases**: Try saving duplicate contacts, empty results, and contacts with missing fields
- [ ] **Verify user feedback**: Confirm the new toast message format provides clear feedback about the save operation

### Notes
**Testing limitation**: I was unable to test the full frontend flow due to authentication requirements, so I only verified the backend API endpoints work correctly with curl. The backend tests confirmed contacts can be saved to and retrieved from the SQLite database successfully.

**Session info**: Requested by @deenabandi004-byte  
**Link to Devin run**: https://app.devin.ai/sessions/480b15b9208d4f6c83cb8232ffd8534a