### PR TITLE
Implement 2-tier pricing system (Free/Pro) with 85 credits per contact

### DIFF
--- a/connect-grow-hire/src/pages/AccountSettings.tsx
+++ b/connect-grow-hire/src/pages/AccountSettings.tsx
@@ -116,6 +116,7 @@ export default function AccountSettings() {
               <div>
                 <CardTitle>Credit Usage Jul-Aug 2025</CardTitle>
                 <p className="text-2xl font-bold text-foreground mt-2">12,127 credits</p>
+                <p className="text-sm text-muted-foreground mt-1">85 credits per contact</p>
               </div>
               <div className="flex items-center gap-4">
                 <Button variant="outline" size="sm" className="flex items-center gap-2">

--- a/connect-grow-hire/src/pages/Home.tsx
+++ b/connect-grow-hire/src/pages/Home.tsx
@@ -17,28 +17,22 @@ import LockedFeatureOverlay from "@/components/LockedFeatureOverlay";
 
 const BACKEND_URL = 'http://localhost:5001';
 
+const CREDITS_PER_CONTACT = 85;
+
 const TIER_CONFIGS = {
   free: {
-    maxContacts: 4,
+    maxContacts: 10,
     name: 'Free',
-    credits: 500,
-    description: 'Basic search - 4 contacts',
+    credits: 850,
+    description: 'Try out platform risk free',
     coffeeChat: false,
     interviewPrep: false
   },
-  starter: {
-    maxContacts: 6,
-    name: 'Starter',
-    credits: 1000,
-    description: 'Advanced search - 6 contacts + Email drafts',
-    coffeeChat: true,
-    interviewPrep: false
-  },
   pro: {
-    maxContacts: 8,
+    maxContacts: 56,
     name: 'Pro',
-    credits: 2000,
-    description: 'Full search - 8 contacts + Resume matching',
+    credits: 4800,
+    description: 'Everything in Free plus directory saves, priority support, advanced features',
     coffeeChat: true,
     interviewPrep: true
   }
@@ -65,7 +59,7 @@ const Home = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
   
-  const [userTier] = useState<'free' | 'starter' | 'pro'>('free');
+  const [userTier] = useState<'free' | 'pro'>('free');
   
   // Form state
   const [jobTitle, setJobTitle] = useState("");
@@ -156,9 +150,7 @@ const Home = () => {
 
       // Map tier to endpoint
       let endpoint = '/api/basic-run';
-      if (userTier === 'starter') {
-        endpoint = '/api/advanced-run';
-      } else if (userTier === 'pro') {
+      if (userTier === 'pro') {
         endpoint = '/api/pro-run';
       }
 
@@ -195,7 +187,9 @@ const Home = () => {
       });
       
       // Deduct credits (mock)
-      mockUser.credits -= currentTierConfig.credits;
+      const foundCount = (data.contacts || []).length;
+      const cost = foundCount * CREDITS_PER_CONTACT;
+      mockUser.credits = Math.max(0, mockUser.credits - cost);
       
     } catch (error) {
       console.error('Search failed:', error);
@@ -222,6 +216,11 @@ const Home = () => {
   });
 
   const handleSaveToDirectory = async () => {
+    if (userTier !== 'pro') {
+      toast({ title: "Pro feature", description: "Upgrade to Pro to save to directory.", variant: "destructive" });
+      return;
+    }
+
     try {
       if (!hasResults) return;
       const mapped = lastResults.map(mapToDirectoryContact);
@@ -400,9 +399,9 @@ const Home = () => {
                     {userTier === 'pro' && <Crown className="h-5 w-5 text-yellow-400" />}
                     <h2 className="text-2xl font-bold text-white">{currentTierConfig.name}</h2>
                   </div>
-                  <Badge className="bg-gradient-to-r from-pink-500 to-purple-500 text-white border-0">
+                  <div className="bg-gradient-to-r from-pink-500 to-purple-500 text-white border-0 px-3 py-1 rounded-full text-sm font-medium">
                     {currentTierConfig.credits} credits
-                  </Badge>
+                  </div>
                 </div>
                 
                 <div className="p-4 bg-gray-800/50 rounded-lg border border-gray-700">
@@ -559,9 +558,9 @@ const Home = () => {
                       <CardTitle className="text-xl text-white flex items-center gap-2">
                         Coffee Chat Prep
                         {currentTierConfig.coffeeChat && (
-                          <Badge variant="outline" className="text-green-400 border-green-400">
+                          <span className="text-green-400 border border-green-400 px-2 py-1 rounded text-xs">
                             Available
-                          </Badge>
+                          </span>
                         )}
                       </CardTitle>
                     </CardHeader>
@@ -625,9 +624,9 @@ const Home = () => {
                       <CardTitle className="text-xl text-white flex items-center gap-2">
                         Interview Prep
                         {currentTierConfig.interviewPrep && (
-                          <Badge variant="outline" className="text-green-400 border-green-400">
+                          <span className="text-green-400 border border-green-400 px-2 py-1 rounded text-xs">
                             Available
-                          </Badge>
+                          </span>
                         )}
                       </CardTitle>
                     </CardHeader>

--- a/connect-grow-hire/src/pages/Index.tsx
+++ b/connect-grow-hire/src/pages/Index.tsx
@@ -296,48 +296,44 @@ const Index = () => {
               Choose Your Plan
             </h2>
             <p className="text-xl text-gray-300">
-              Find the perfect plan to accelerate your career journey
+              85 credits per contact. When you run out of credits, no more contacts.
             </p>
           </div>
 
-          <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
-            {/* Free Trial Plan */}
+          <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+            {/* Free Plan */}
             <div className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-8 border border-gray-700">
-              <h3 className="text-2xl font-bold mb-2">Free Trial</h3>
-              <div className="mb-6">
-                <span className="text-4xl font-bold">$0</span>
-                <span className="text-gray-400">/month</span>
-              </div>
-              <p className="text-gray-300 mb-8">Perfect for getting started and exploring our platform</p>
+              <h3 className="text-2xl font-bold mb-2">Free</h3>
+              <p className="text-gray-300 mb-8">Try out platform risk free</p>
               
               <ul className="space-y-4 mb-8">
                 <li className="flex items-center gap-3">
                   <Check className="w-5 h-5 text-green-400" />
-                  <span>Up to 10 candidate profiles</span>
+                  <span>850 credits</span>
                 </li>
                 <li className="flex items-center gap-3">
                   <Check className="w-5 h-5 text-green-400" />
-                  <span>Basic search filters</span>
+                  <span>Estimated time saved: 200 minutes</span>
                 </li>
                 <li className="flex items-center gap-3">
                   <Check className="w-5 h-5 text-green-400" />
-                  <span>Email templates</span>
+                  <span>Try out platform risk free</span>
                 </li>
                 <li className="flex items-center gap-3">
                   <Check className="w-5 h-5 text-green-400" />
-                  <span>Basic analytics</span>
+                  <span>Limited Features</span>
                 </li>
               </ul>
               
               <button 
-                onClick={() => navigate("/onboarding/resume-upload")}
+                onClick={() => navigate("/onboarding")}
                 className="w-full bg-gray-700 hover:bg-gray-600 text-white py-3 px-6 rounded-xl font-semibold transition-colors"
               >
-                Start Free Trial
+                Start for free
               </button>
             </div>
 
-            {/* Starter Plan */}
+            {/* Pro Plan */}
             <div className="bg-gradient-to-br from-blue-500/20 to-purple-500/20 backdrop-blur-sm rounded-2xl p-8 border border-blue-500/50 relative">
               <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
                 <span className="bg-gradient-to-r from-blue-500 to-purple-500 text-white px-4 py-1 rounded-full text-sm font-medium">
@@ -345,33 +341,32 @@ const Index = () => {
                 </span>
               </div>
               
-              <h3 className="text-2xl font-bold mb-2">Starter</h3>
-              <div className="mb-6">
-                <span className="text-4xl font-bold">$24.99</span>
-                <span className="text-gray-400">/month</span>
-              </div>
-              <p className="text-gray-300 mb-8">Ideal for individual recruiters and small teams</p>
+              <h3 className="text-2xl font-bold mb-2">Pro</h3>
               
               <ul className="space-y-4 mb-8">
                 <li className="flex items-center gap-3">
                   <Check className="w-5 h-5 text-green-400" />
-                  <span>Up to 100 candidate profiles</span>
+                  <span>4800 credits</span>
                 </li>
                 <li className="flex items-center gap-3">
                   <Check className="w-5 h-5 text-green-400" />
-                  <span>Advanced search & filters</span>
+                  <span>Estimated time saved: 1200 minutes</span>
                 </li>
                 <li className="flex items-center gap-3">
                   <Check className="w-5 h-5 text-green-400" />
-                  <span>AI-powered matching</span>
+                  <span>Everything in free plus:</span>
                 </li>
-                <li className="flex items-center gap-3">
+                <li className="flex items-center gap-3 ml-4">
                   <Check className="w-5 h-5 text-green-400" />
-                  <span>Automated outreach</span>
+                  <span>Directory permanently saves</span>
                 </li>
-                <li className="flex items-center gap-3">
+                <li className="flex items-center gap-3 ml-4">
                   <Check className="w-5 h-5 text-green-400" />
-                  <span>Basic mentorship access</span>
+                  <span>Priority Support</span>
+                </li>
+                <li className="flex items-center gap-3 ml-4">
+                  <Check className="w-5 h-5 text-green-400" />
+                  <span>Advanced features</span>
                 </li>
               </ul>
               
@@ -379,51 +374,7 @@ const Index = () => {
                 onClick={() => navigate("/onboarding/resume-upload")}
                 className="w-full bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white py-3 px-6 rounded-xl font-semibold transition-all"
               >
-                Get Started
-              </button>
-            </div>
-
-            {/* Pro Plan */}
-            <div className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-8 border border-gray-700">
-              <h3 className="text-2xl font-bold mb-2">Pro</h3>
-              <div className="mb-6">
-                <span className="text-4xl font-bold">$39.99</span>
-                <span className="text-gray-400">/month</span>
-              </div>
-              <p className="text-gray-300 mb-8">For growing teams and agencies with advanced needs</p>
-              
-              <ul className="space-y-4 mb-8">
-                <li className="flex items-center gap-3">
-                  <Check className="w-5 h-5 text-green-400" />
-                  <span>Unlimited candidate profiles</span>
-                </li>
-                <li className="flex items-center gap-3">
-                  <Check className="w-5 h-5 text-green-400" />
-                  <span>Premium AI personalizations</span>
-                </li>
-                <li className="flex items-center gap-3">
-                  <Check className="w-5 h-5 text-green-400" />
-                  <span>Advanced analytics & insights</span>
-                </li>
-                <li className="flex items-center gap-3">
-                  <Check className="w-5 h-5 text-green-400" />
-                  <span>Priority mentorship access</span>
-                </li>
-                <li className="flex items-center gap-3">
-                  <Check className="w-5 h-5 text-green-400" />
-                  <span>Custom integrations</span>
-                </li>
-                <li className="flex items-center gap-3">
-                  <Check className="w-5 h-5 text-green-400" />
-                  <span>Priority support</span>
-                </li>
-              </ul>
-              
-              <button 
-                onClick={() => navigate("/onboarding/resume-upload")}
-                className="w-full bg-gray-700 hover:bg-gray-600 text-white py-3 px-6 rounded-xl font-semibold transition-colors"
-              >
-                Get Started
+                Start now
               </button>
             </div>
           </div>

--- a/connect-grow-hire/src/pages/Pricing.tsx
+++ b/connect-grow-hire/src/pages/Pricing.tsx
@@ -1,140 +1,52 @@
-import { useState } from "react";
-import { Check, X, ArrowLeft, CreditCard } from "lucide-react";
+import { ArrowLeft, CreditCard } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { useNavigate } from "react-router-dom";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 
 const Pricing = () => {
-  const [isAnnual, setIsAnnual] = useState(false);
   const navigate = useNavigate();
 
   const plans = [
     {
       name: "Free",
-      price: "$0",
-      period: "/month",
-      description: "Perfect for getting started",
-      buttonText: "Get Started",
-      buttonVariant: "outline" as const,
-      popular: false,
-      features: {
-        creditsPerMonth: "500",
-        batchSize: "4",
-        monthlyReachOuts: "20",
-        seats: "–",
-        gmailDrafts: false,
-        infoAutoInserted: "Basic fields",
-        starterEmailWriter: false,
-        proEmailWriter: false,
-      }
-    },
-    {
-      name: "Starter",
-      price: "$47",
-      period: "/month",
-      description: "For growing professionals",
-      buttonText: "Upgrade Plan",
-      buttonVariant: "default" as const,
-      popular: false,
-      features: {
-        creditsPerMonth: "11,000",
-        batchSize: "6",
-        monthlyReachOuts: "96",
-        seats: "–",
-        gmailDrafts: true,
-        infoAutoInserted: "All fields",
-        starterEmailWriter: true,
-        proEmailWriter: false,
-      }
+      credits: 850,
+      emails: 10,
+      timeSavedMinutes: 200,
+      description: "Try out platform risk free",
+      bullets: [
+        "850 credits",
+        "Estimated time saved: 200 minutes",
+        "Try out platform risk free",
+        "Limited Features",
+      ],
+      cta: { label: "Start for free", to: "/onboarding" },
     },
     {
       name: "Pro",
-      price: "$97",
-      period: "/month",
-      description: "For serious networking",
-      buttonText: "Upgrade Plan",
-      buttonVariant: "default" as const,
-      popular: true,
-      features: {
-        creditsPerMonth: "31,000",
-        batchSize: "8",
-        monthlyReachOuts: "160",
-        seats: "–",
-        gmailDrafts: true,
-        infoAutoInserted: "All fields",
-        starterEmailWriter: true,
-        proEmailWriter: true,
-      }
+      credits: 4800,
+      emails: 56,
+      timeSavedMinutes: 1200,
+      description: "",
+      bullets: [
+        "4800 credits",
+        "Estimated time saved: 1200 minutes",
+        "Everything in free plus:",
+        "- Directory permanently saves",
+        "- Priority Support",
+        "- Advanced features",
+      ],
+      cta: { label: "Start now", to: "/onboarding/resume-upload" },
     },
-    {
-      name: "Enterprise",
-      price: "Custom",
-      period: "",
-      description: "For teams and organizations",
-      buttonText: "Contact Us",
-      buttonVariant: "outline" as const,
-      popular: false,
-      features: {
-        creditsPerMonth: "Custom",
-        batchSize: "Custom",
-        monthlyReachOuts: "Custom",
-        seats: "–",
-        gmailDrafts: true,
-        infoAutoInserted: "All fields",
-        starterEmailWriter: true,
-        proEmailWriter: true,
-      }
-    }
   ];
-
-  const infoFields = [
-    "First Name",
-    "Last Name", 
-    "Email Address",
-    "LinkedIn URL",
-    "College",
-    "Location",
-    "Company",
-    "Hometown",
-    "Work Experience",
-    "Volunteer Work",
-    "Clubs",
-    "Interests"
-  ];
-
-  const getFieldAccess = (planName: string, field: string) => {
-    if (planName === "Free") {
-      return ["First Name", "Last Name", "Email Address", "LinkedIn URL"].includes(field);
-    }
-    if (planName === "Starter") {
-      return ["First Name", "Last Name", "Email Address", "LinkedIn URL", "College", "Location", "Company"].includes(field);
-    }
-    return true; // Pro and Enterprise get all fields
-  };
 
   return (
-    <div className="min-h-screen bg-gradient-subtle">
-      {/* Header with back button */}
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800">
       <div className="container mx-auto px-6 py-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate("/home")}
-          className="mb-8 hover:bg-accent"
-        >
+        <Button variant="ghost" onClick={() => navigate("/home")} className="mb-8 hover:bg-accent">
           <ArrowLeft className="mr-2 h-4 w-4" />
           Back to Home
         </Button>
 
-        {/* Hero Section */}
         <div className="text-center mb-16">
           <div className="flex items-center justify-center gap-2 mb-4">
             <CreditCard className="h-8 w-8 text-primary" />
@@ -144,232 +56,29 @@ const Pricing = () => {
             Choose a plan to match your needs
           </h1>
           <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-            Upgrade or cancel subscriptions anytime. All prices are USD.
+            85 credits per contact. When you run out of credits, no more contacts.
           </p>
-
-          {/* Billing Toggle */}
-          <div className="flex items-center justify-center gap-4 mb-12">
-            <span className={`text-sm ${!isAnnual ? 'text-foreground font-medium' : 'text-muted-foreground'}`}>
-              Monthly
-            </span>
-            <button
-              onClick={() => setIsAnnual(!isAnnual)}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                isAnnual ? 'bg-primary' : 'bg-muted'
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-background transition-transform ${
-                  isAnnual ? 'translate-x-6' : 'translate-x-1'
-                }`}
-              />
-            </button>
-            <span className={`text-sm ${isAnnual ? 'text-foreground font-medium' : 'text-muted-foreground'}`}>
-              Annual
-            </span>
-          </div>
         </div>
 
-        {/* Pricing Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-16">
           {plans.map((plan) => (
-            <Card
-              key={plan.name}
-              className={`relative h-full transition-all hover:shadow-soft ${
-                plan.popular ? 'border-primary ring-2 ring-primary/20' : 'border-border'
-              }`}
-            >
-              {plan.popular && (
-                <Badge className="absolute -top-3 left-1/2 transform -translate-x-1/2 bg-primary text-primary-foreground">
-                  Most Popular
-                </Badge>
-              )}
-              
-              <CardHeader className="text-center pb-8">
+            <Card key={plan.name} className="relative h-full border-border hover:shadow-lg transition-all">
+              <CardHeader className="text-center pb-4">
                 <CardTitle className="text-lg font-semibold mb-2">{plan.name}</CardTitle>
-                <div className="mb-4">
-                  <span className="text-4xl font-bold">{plan.price}</span>
-                  <span className="text-muted-foreground">{plan.period}</span>
-                </div>
-                <p className="text-sm text-muted-foreground">{plan.description}</p>
+                {plan.description && <p className="text-sm text-muted-foreground">{plan.description}</p>}
               </CardHeader>
-
-              <CardContent className="pt-0">
-                <Button 
-                  className="w-full mb-6" 
-                  variant={plan.buttonVariant}
-                  onClick={() => plan.name === "Enterprise" ? navigate("/contact") : navigate("/onboarding/resume-upload")}
-                >
-                  {plan.buttonText}
+              <CardContent>
+                <ul className="space-y-2 mb-6">
+                  {plan.bullets.map((b, i) => (
+                    <li key={i} className="text-sm text-foreground">{b}</li>
+                  ))}
+                </ul>
+                <Button className="w-full" onClick={() => navigate(plan.cta.to)}>
+                  {plan.cta.label}
                 </Button>
               </CardContent>
             </Card>
           ))}
-        </div>
-
-        {/* Features Comparison Table */}
-        <div className="bg-card rounded-lg border shadow-card overflow-hidden mb-16">
-          <div className="p-6 border-b">
-            <h2 className="text-2xl font-bold text-center">Plan Comparison</h2>
-          </div>
-          
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-1/4">Feature</TableHead>
-                <TableHead className="text-center">Free</TableHead>
-                <TableHead className="text-center">Starter</TableHead>
-                <TableHead className="text-center bg-primary/5">Pro</TableHead>
-                <TableHead className="text-center">Enterprise</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              <TableRow>
-                <TableCell className="font-medium">Credits per Month</TableCell>
-                <TableCell className="text-center">{plans[0].features.creditsPerMonth}</TableCell>
-                <TableCell className="text-center">{plans[1].features.creditsPerMonth}</TableCell>
-                <TableCell className="text-center bg-primary/5">{plans[2].features.creditsPerMonth}</TableCell>
-                <TableCell className="text-center">{plans[3].features.creditsPerMonth}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="font-medium">Batch Size (per run)</TableCell>
-                <TableCell className="text-center">{plans[0].features.batchSize}</TableCell>
-                <TableCell className="text-center">{plans[1].features.batchSize}</TableCell>
-                <TableCell className="text-center bg-primary/5">{plans[2].features.batchSize}</TableCell>
-                <TableCell className="text-center">{plans[3].features.batchSize}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="font-medium">Monthly Reach Outs</TableCell>
-                <TableCell className="text-center">{plans[0].features.monthlyReachOuts}</TableCell>
-                <TableCell className="text-center">{plans[1].features.monthlyReachOuts}</TableCell>
-                <TableCell className="text-center bg-primary/5">{plans[2].features.monthlyReachOuts}</TableCell>
-                <TableCell className="text-center">{plans[3].features.monthlyReachOuts}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="font-medium">Time Saved (per click)</TableCell>
-                <TableCell className="text-center">20 minutes</TableCell>
-                <TableCell className="text-center">72 minutes</TableCell>
-                <TableCell className="text-center bg-primary/5">240 minutes</TableCell>
-                <TableCell className="text-center">Custom</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="font-medium">Time Saved (per month)</TableCell>
-                <TableCell className="text-center">100 minutes</TableCell>
-                <TableCell className="text-center">1,152 minutes</TableCell>
-                <TableCell className="text-center bg-primary/5">4,800 minutes</TableCell>
-                <TableCell className="text-center">Custom</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="font-medium">Gmail Drafts</TableCell>
-                <TableCell className="text-center">
-                  {plans[0].features.gmailDrafts ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-                <TableCell className="text-center">
-                  {plans[1].features.gmailDrafts ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-                <TableCell className="text-center bg-primary/5">
-                  {plans[2].features.gmailDrafts ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-                <TableCell className="text-center">
-                  {plans[3].features.gmailDrafts ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="font-medium">Info Auto-Inserted</TableCell>
-                <TableCell className="text-center text-sm">{plans[0].features.infoAutoInserted}</TableCell>
-                <TableCell className="text-center text-sm">Limited fields</TableCell>
-                <TableCell className="text-center text-sm bg-primary/5">{plans[2].features.infoAutoInserted}</TableCell>
-                <TableCell className="text-center text-sm">{plans[3].features.infoAutoInserted}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="font-medium">Starter Email Writer</TableCell>
-                <TableCell className="text-center">
-                  {plans[0].features.starterEmailWriter ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-                <TableCell className="text-center">
-                  {plans[1].features.starterEmailWriter ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-                <TableCell className="text-center bg-primary/5">
-                  {plans[2].features.starterEmailWriter ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-                <TableCell className="text-center">
-                  {plans[3].features.starterEmailWriter ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="font-medium">Pro Email Writer</TableCell>
-                <TableCell className="text-center">
-                  {plans[0].features.proEmailWriter ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-                <TableCell className="text-center">
-                  {plans[1].features.proEmailWriter ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-                <TableCell className="text-center bg-primary/5">
-                  {plans[2].features.proEmailWriter ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-                <TableCell className="text-center">
-                  {plans[3].features.proEmailWriter ? <Check className="h-4 w-4 text-primary mx-auto" /> : <X className="h-4 w-4 text-muted-foreground mx-auto" />}
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </div>
-
-        {/* Email Writer Features */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-16">
-          <Card className="border shadow-card">
-            <CardHeader>
-              <CardTitle className="text-xl">Starter Email Writer</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">
-                Crafts a strong, professional email template based on your background and goals. 
-                Just add a few details and send.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card className="border shadow-card bg-primary/5">
-            <CardHeader>
-              <CardTitle className="text-xl">Pro Email Writer</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">
-                Uploads your resume and generates a personalized, ready-to-send email that highlights 
-                your similarities with the recipient for better results.
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Information Fields */}
-        <div className="bg-card rounded-lg border shadow-card p-8">
-          <h2 className="text-2xl font-bold text-center mb-8">Information Provided</h2>
-          <p className="text-center text-muted-foreground mb-8">
-            User data that can be auto-inserted into emails for each plan
-          </p>
-          
-          <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-            {plans.map((plan) => (
-              <div key={plan.name} className={`space-y-4 ${plan.name === 'Pro' ? 'bg-primary/5 p-4 rounded-lg' : ''}`}>
-                <h3 className="font-semibold text-center text-lg">{plan.name}</h3>
-                <div className="space-y-2">
-                  {infoFields.map((field) => (
-                    <div key={field} className="flex items-center gap-2">
-                      {getFieldAccess(plan.name, field) ? (
-                        <Check className="h-4 w-4 text-primary flex-shrink-0" />
-                      ) : (
-                        <X className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                      )}
-                      <span className={`text-sm ${getFieldAccess(plan.name, field) ? 'text-foreground' : 'text-muted-foreground'}`}>
-                        {field}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Implement 2-tier pricing system (Free/Pro) with 85 credits per contact

## Summary
Simplified the pricing structure from a 4-tier system (Free/Starter/Pro/Enterprise) to a streamlined 2-tier system (Free/Pro) with credit-based pricing. Key changes:

- **Free tier**: 850 credits, ~10 contacts at 85 credits each, 200 minutes time saved
- **Pro tier**: 4800 credits, ~56 contacts at 85 credits each, 1200 minutes time saved  
- **Credit deduction**: Changed from fixed tier costs to dynamic 85 credits per contact found
- **Feature restrictions**: Directory save now requires Pro tier (UI-enforced)
- **Updated all pricing displays**: Pricing page, landing page, home page, and account settings

## Review & Testing Checklist for Human
- [ ] **Verify credit math works correctly** - Test searches and confirm credits are deducted as `contacts_found × 85` (high risk: untested due to dependency issues)
- [ ] **Test tier-to-endpoint mapping** - Confirm Free tier calls `/api/basic-run` and Pro tier calls `/api/pro-run` correctly  
- [ ] **End-to-end user flows** - Test both Free→onboarding and Pro→onboarding/resume-upload paths work
- [ ] **Pro feature restrictions** - Verify directory save shows "Pro feature" message for free users and works for Pro users
- [ ] **Pricing display consistency** - Check all pricing amounts (850/4800 credits, 200/1200 minutes) appear correctly across pages

### Notes
- Backend still has 3-tier structure (basic/advanced/pro) but frontend now only uses 2 tiers
- Could not test locally due to React/lucide-react dependency issues - **manual testing required**
- Pro-only restrictions are UI-enforced only, consider backend validation if needed
- Removed Starter tier completely and updated all references

**Link to Devin run**: https://app.devin.ai/sessions/42c14a7e57284d46ae402f21d2c2284d  
**Requested by**: Deena Siddharth Bandi (@deenabandi004-byte)